### PR TITLE
Rename "DEBUG" enum

### DIFF
--- a/src/drw_base.h
+++ b/src/drw_base.h
@@ -103,9 +103,9 @@ BAD_READ_ENTITIES,    /*!< error in entities read process. */
 BAD_READ_OBJECTS      /*!< error in objects read process. */
 };
 
-enum DBG_LEVEL {
-    NONE,
-    DEBUG
+enum class DebugLevel {
+    None,
+    Debug
 };
 
 //! Special codes for colors

--- a/src/drw_entities.cpp
+++ b/src/drw_entities.cpp
@@ -1267,7 +1267,7 @@ bool DRW_LWPolyline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
             }
         }
     }
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
         DRW_DBG("\nVertex list: ");
 		for (auto& pv: vertlist) {
             DRW_DBG("\n   x: "); DRW_DBG(pv->x); DRW_DBG(" y: "); DRW_DBG(pv->y); DRW_DBG(" bulge: "); DRW_DBG(pv->bulge);
@@ -2156,7 +2156,7 @@ bool DRW_Spline::parseDwg(DRW::Version version, dwgBuffer *buf, duint32 bs){
 	for (dint32 i= 0; i<nfit; ++i)
 		fitlist.push_back(std::make_shared<DRW_Coord>(buf->get3BitDouble()));
 
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
 		DRW_DBG("\nknots list: ");
 		for (auto const& v: knotslist) {
 			DRW_DBG("\n"); DRW_DBG(v);

--- a/src/drw_header.cpp
+++ b/src/drw_header.cpp
@@ -2362,7 +2362,7 @@ bool DRW_Header::parseDwg(DRW::Version version, dwgBuffer *buf, dwgBuffer *hBbuf
     DRW_DBG("\nstring buf position: "); DRW_DBG(buf->getPosition());
     DRW_DBG("  string buf bit position: "); DRW_DBG(buf->getBitPos());
 
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
         for (std::map<std::string,DRW_Variant*>::iterator it=vars.begin(); it!=vars.end(); ++it){
             DRW_DBG("\n"); DRW_DBG(it->first); DRW_DBG(": ");
             switch (it->second->type()){

--- a/src/intern/drw_dbg.cpp
+++ b/src/intern/drw_dbg.cpp
@@ -56,24 +56,23 @@ DRW_dbg *DRW_dbg::getInstance(){
 }
 
 DRW_dbg::DRW_dbg(){
-    level = NONE;
     prClass = new print_none;
     flags = std::cerr.flags();
 }
 
-void DRW_dbg::setLevel(LEVEL lvl){
+void DRW_dbg::setLevel(Level lvl){
     level = lvl;
     delete prClass;
     switch (level){
-    case DEBUG:
+    case Level::Debug:
         prClass = new print_debug;
         break;
-    default:
+    case Level::None:
         prClass = new print_none;
     }
 }
 
-DRW_dbg::LEVEL DRW_dbg::getLevel(){
+DRW_dbg::Level DRW_dbg::getLevel(){
     return level;
 }
 

--- a/src/intern/drw_dbg.h
+++ b/src/intern/drw_dbg.h
@@ -30,12 +30,12 @@ class print_none;
 
 class DRW_dbg {
 public:
-    enum LEVEL {
-        NONE,
-        DEBUG
+    enum class Level {
+        None,
+        Debug
     };
-    void setLevel(LEVEL lvl);
-    LEVEL getLevel();
+    void setLevel(Level lvl);
+    Level getLevel();
     static DRW_dbg *getInstance();
     void print(std::string s);
     void print(int i);
@@ -52,7 +52,7 @@ public:
 private:
     DRW_dbg();
     static DRW_dbg *instance;
-    LEVEL level;
+    Level level{Level::None};
     std::ios_base::fmtflags flags;
     print_none* prClass;
 };

--- a/src/intern/dwgreader.cpp
+++ b/src/intern/dwgreader.cpp
@@ -615,7 +615,7 @@ bool dwgReader::readDwgTables(DRW_Header& hdr, dwgBuffer *dbuf) {
     }
 
     //RLZ: parse remaining object controls, TODO: implement all
-    if (DRW_DBGGL == DRW_dbg::DEBUG){
+    if (DRW_DBGGL == DRW_dbg::Level::Debug){
         mit = ObjectMap.find(hdr.viewCtrl);
         if (mit==ObjectMap.end()) {
             DRW_DBG("\nWARNING: View control not found\n");
@@ -1184,7 +1184,7 @@ bool dwgReader::readDwgObjects(DRW_Interface& intfa, dwgBuffer *dbuf){
         if (ret)
             ret = ret2;
     }
-    if (DRW_DBGGL == DRW_dbg::DEBUG) {
+    if (DRW_DBGGL == DRW_dbg::Level::Debug) {
         for (std::map<duint32, objHandle>::iterator it=remainingMap.begin(); it != remainingMap.end(); ++it){
             DRW_DBG("\nnum.# "); DRW_DBG(i++); DRW_DBG(" Remaining object Handle, loc, type= "); DRW_DBG(it->first);
             DRW_DBG(" "); DRW_DBG(it->second.loc); DRW_DBG(" "); DRW_DBG(it->second.type);

--- a/src/libdwgr.cpp
+++ b/src/libdwgr.cpp
@@ -38,18 +38,18 @@
 dwgR::dwgR(const char* name)
     : fileName{ name }
 {
-    DRW_DBGSL(DRW_dbg::NONE);
+    DRW_DBGSL(DRW_dbg::Level::None);
 }
 
 dwgR::~dwgR() = default;
 
-void dwgR::setDebug(DRW::DBG_LEVEL lvl){
+void dwgR::setDebug(DRW::DebugLevel lvl){
     switch (lvl){
-    case DRW::DEBUG:
-        DRW_DBGSL(DRW_dbg::DEBUG);
+    case DRW::DebugLevel::Debug:
+        DRW_DBGSL(DRW_dbg::Level::Debug);
         break;
-    default:
-        DRW_DBGSL(DRW_dbg::NONE);
+    case DRW::DebugLevel::None:
+        DRW_DBGSL(DRW_dbg::Level::None);
     }
 }
 

--- a/src/libdwgr.h
+++ b/src/libdwgr.h
@@ -34,7 +34,7 @@ public:
     DRW::Version getVersion(){return version;}
     DRW::error getError(){return error;}
 bool testReader();
-    void setDebug(DRW::DBG_LEVEL lvl);
+    void setDebug(DRW::DebugLevel lvl);
 
 private:
     bool openFile(std::ifstream *filestr);

--- a/src/libdxfrw.cpp
+++ b/src/libdxfrw.cpp
@@ -33,7 +33,7 @@
 };*/
 
 dxfRW::dxfRW(const char* name){
-    DRW_DBGSL(DRW_dbg::NONE);
+    DRW_DBGSL(DRW_dbg::Level::None);
     fileName = name;
     reader = NULL;
     writer = NULL;
@@ -51,13 +51,13 @@ dxfRW::~dxfRW(){
     imageDef.clear();
 }
 
-void dxfRW::setDebug(DRW::DBG_LEVEL lvl){
+void dxfRW::setDebug(DRW::DebugLevel lvl){
     switch (lvl){
-    case DRW::DEBUG:
-        DRW_DBGSL(DRW_dbg::DEBUG);
+    case DRW::DebugLevel::Debug:
+        DRW_DBGSL(DRW_dbg::Level::Debug);
         break;
-    default:
-        DRW_DBGSL(DRW_dbg::NONE);
+    case DRW::DebugLevel::None:
+        DRW_DBGSL(DRW_dbg::Level::None);
     }
 }
 

--- a/src/libdxfrw.h
+++ b/src/libdxfrw.h
@@ -27,7 +27,7 @@ class dxfRW {
 public:
     dxfRW(const char* name);
     ~dxfRW();
-    void setDebug(DRW::DBG_LEVEL lvl);
+    void setDebug(DRW::DebugLevel lvl);
     /// reads the file specified in constructor
     /*!
      * An interface must be provided. It is used by the class to signal various


### PR DESCRIPTION
This was required for the QGIS fork, where "DEBUG" is a macro set by Qt. (I've upgraded it to a enum class while I'm at it)