### PR TITLE
Add interface to allow custom output debuggers to be set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(libdxfrw_srcs
   src/intern/dxfreader.cpp
   src/intern/dxfwriter.cpp
   src/intern/rscodec.cpp
+  src/drw_base.cpp
   src/drw_classes.cpp
   src/drw_entities.cpp
   src/drw_header.cpp

--- a/src/drw_base.cpp
+++ b/src/drw_base.cpp
@@ -1,0 +1,19 @@
+/******************************************************************************
+**  libDXFrw - Library to read/write DXF files (ascii & binary)              **
+**                                                                           **
+**  Copyright (C) 2011-2015 José F. Soriano, rallazz@gmail.com               **
+**                                                                           **
+**  This library is free software, licensed under the terms of the GNU       **
+**  General Public License as published by the Free Software Foundation,     **
+**  either version 2 of the License, or (at your option) any later version.  **
+**  You should have received a copy of the GNU General Public License        **
+**  along with this program.  If not, see <http://www.gnu.org/licenses/>.    **
+******************************************************************************/
+
+#include "drw_base.h"
+#include "intern/drw_dbg.h"
+
+void DRW::setCustomDebugPrinter(DebugPrinter *printer)
+{
+  DRW_dbg::getInstance()->setCustomDebugPrinter(std::unique_ptr<DebugPrinter>(printer));
+}

--- a/src/drw_base.cpp
+++ b/src/drw_base.cpp
@@ -17,3 +17,5 @@ void DRW::setCustomDebugPrinter(DebugPrinter *printer)
 {
   DRW_dbg::getInstance()->setCustomDebugPrinter(std::unique_ptr<DebugPrinter>(printer));
 }
+
+DRW::DebugPrinter::~DebugPrinter() = default;

--- a/src/drw_base.h
+++ b/src/drw_base.h
@@ -124,7 +124,7 @@ public:
     virtual void printHL(int c, int s, int h){(void)c;(void)s;(void)h;}
     virtual void printPT(double x, double y, double z){(void)x;(void)y;(void)z;}
     DebugPrinter()=default;
-    virtual ~DebugPrinter()=default;
+    virtual ~DebugPrinter();
 };
 
 /**

--- a/src/drw_base.h
+++ b/src/drw_base.h
@@ -108,6 +108,32 @@ enum class DebugLevel {
     Debug
 };
 
+/**
+ * Interface for debug printers.
+ *
+ * The base class is silent and ignores all debugging.
+ */
+class DebugPrinter {
+public:
+    virtual void printS(const std::string &s){(void)s;}
+    virtual void printI(long long int i){(void)i;}
+    virtual void printUI(long long unsigned int i){(void)i;}
+    virtual void printD(double d){(void)d;}
+    virtual void printH(long long int i){(void)i;}
+    virtual void printB(int i){(void)i;}
+    virtual void printHL(int c, int s, int h){(void)c;(void)s;(void)h;}
+    virtual void printPT(double x, double y, double z){(void)x;(void)y;(void)z;}
+    DebugPrinter()=default;
+    virtual ~DebugPrinter()=default;
+};
+
+/**
+ * Sets a custom debug printer to use when outputting debug messages.
+ *
+ * Ownership of `printer` is transferred.
+ */
+void setCustomDebugPrinter( DebugPrinter* printer );
+
 //! Special codes for colors
 enum ColorCodes {
     ColorByLayer = 256,

--- a/src/intern/drw_dbg.cpp
+++ b/src/intern/drw_dbg.cpp
@@ -17,21 +17,8 @@
 DRW_dbg *DRW_dbg::instance{nullptr};
 
 /*********private clases*************/
-class print_none {
-public:
-    virtual void printS(const std::string& s){(void)s;}
-    virtual void printI(long long int i){(void)i;}
-    virtual void printUI(long long unsigned int i){(void)i;}
-    virtual void printD(double d){(void)d;}
-    virtual void printH(long long int i){(void)i;}
-    virtual void printB(int i){(void)i;}
-    virtual void printHL(int c, int s, int h){(void)c;(void)s;(void)h;}
-    virtual void printPT(double x, double y, double z){(void)x;(void)y;(void)z;}
-    print_none()=default;
-    virtual ~print_none()=default;
-};
 
-class print_debug : public print_none {
+class print_debug : public DRW::DebugPrinter {
 public:
     void printS(const std::string& s) override;
     void printI(long long int i) override;
@@ -41,7 +28,6 @@ public:
     void printB(int i) override;
     void printHL(int c, int s, int h) override;
     void printPT(double x, double y, double z) override;
-    print_debug()=default;
 private:
     std::ios_base::fmtflags flags{std::cerr.flags()};
 };
@@ -55,17 +41,26 @@ DRW_dbg *DRW_dbg::getInstance(){
 }
 
 DRW_dbg::DRW_dbg(){
-    prClass.reset( new print_none );
+    debugPrinter.reset(new print_debug);
+    currentPrinter = &silentDebug;
+}
+
+void DRW_dbg::setCustomDebugPrinter(std::unique_ptr<DRW::DebugPrinter> printer)
+{
+    debugPrinter = std::move( printer );
+    if (level == Level::Debug){
+        currentPrinter = debugPrinter.get();
+    }
 }
 
 void DRW_dbg::setLevel(Level lvl){
     level = lvl;
     switch (level){
     case Level::Debug:
-        prClass.reset(new print_debug);
+        currentPrinter = debugPrinter.get();
         break;
     case Level::None:
-        prClass.reset(new print_none);
+        currentPrinter = &silentDebug;
         break;
     }
 }
@@ -75,46 +70,46 @@ DRW_dbg::Level DRW_dbg::getLevel(){
 }
 
 void DRW_dbg::print(const std::string &s){
-    prClass->printS(s);
+    currentPrinter->printS(s);
 }
 
 void DRW_dbg::print(int i){
-    prClass->printI(i);
+    currentPrinter->printI(i);
 }
 
 void DRW_dbg::print(unsigned int i){
-    prClass->printUI(i);
+    currentPrinter->printUI(i);
 }
 
 void DRW_dbg::print(long long int i){
-    prClass->printI(i);
+    currentPrinter->printI(i);
 }
 
 void DRW_dbg::print(long unsigned int i){
-    prClass->printUI(i);
+    currentPrinter->printUI(i);
 }
 
 void DRW_dbg::print(long long unsigned int i){
-    prClass->printUI(i);
+    currentPrinter->printUI(i);
 }
 
 void DRW_dbg::print(double d){
-    prClass->printD(d);
+    currentPrinter->printD(d);
 }
 
 void DRW_dbg::printH(long long int i){
-    prClass->printH(i);
+    currentPrinter->printH(i);
 }
 
 void DRW_dbg::printB(int i){
-    prClass->printB(i);
+    currentPrinter->printB(i);
 }
 void DRW_dbg::printHL(int c, int s, int h){
-    prClass->printHL(c, s, h);
+    currentPrinter->printHL(c, s, h);
 }
 
 void DRW_dbg::printPT(double x, double y, double z){
-    prClass->printPT(x, y, z);
+    currentPrinter->printPT(x, y, z);
 }
 
 void print_debug::printS(const std::string& s){

--- a/src/intern/drw_dbg.h
+++ b/src/intern/drw_dbg.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <iostream>
 #include <memory>
+#include "../drw_base.h"
 //#include <iomanip>
 
 #define DRW_DBGSL(a) DRW_dbg::getInstance()->setLevel(a)
@@ -26,9 +27,6 @@
 #define DRW_DBGHL(a, b, c) DRW_dbg::getInstance()->printHL(a, b ,c)
 #define DRW_DBGPT(a, b, c) DRW_dbg::getInstance()->printPT(a, b, c)
 
-
-class print_none;
-
 class DRW_dbg {
 public:
     enum class Level {
@@ -36,6 +34,11 @@ public:
         Debug
     };
     void setLevel(Level lvl);
+    /**
+     * Sets a custom debug printer to use when non-silent output
+     * is required.
+     */
+    void setCustomDebugPrinter(std::unique_ptr<DRW::DebugPrinter> printer);
     Level getLevel();
     static DRW_dbg *getInstance();
     void print(const std::string& s);
@@ -54,8 +57,9 @@ private:
     DRW_dbg();
     static DRW_dbg *instance;
     Level level{Level::None};
-    std::ios_base::fmtflags flags{std::cerr.flags()};
-    std::unique_ptr<print_none> prClass;
+    DRW::DebugPrinter silentDebug;
+    std::unique_ptr< DRW::DebugPrinter > debugPrinter;
+    DRW::DebugPrinter* currentPrinter{nullptr};
 };
 
 


### PR DESCRIPTION
Allows clients to set their own custom debugging output class, e.g. for situations where printing to std::cerr is not appropriate

One of the most intrusive changes in QGIS' fork was that the debugging code was replaced with hardcoded changes to redirect the output to QGIS' internal logging mechanism. In this PR I've setup an interface to allow clients to create custom output debugging classes and assign these to be used by the library.

This will allow me to remove all the related downstream changes in QGIS' fork and re-sync these files back to upstream.